### PR TITLE
homeassistant: fix restart whitin configuration

### DIFF
--- a/homeassistant/files/homeassistant
+++ b/homeassistant/files/homeassistant
@@ -7,5 +7,6 @@ start_service()
     procd_set_param command hass --config /etc/homeassistant --log-file /var/log/home-assistant.log --log-rotate-days 3
     procd_set_param stdout 1
     procd_set_param stderr 1
+    procd_set_param respawn ${respawn_threshold:-3600} ${respawn_timeout:-5} ${respawn_retry:-5}
     procd_close_instance
 }


### PR DESCRIPTION
propper shutdown is also needed

daemon.info procd: Instance homeassistant::instance1 pid 2842 not stopped on SIGTERM, sending SIGKILL instead
hint: instance_stop()

Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>