### PR TITLE
homeassistant: update to 2022.4.5

### DIFF
--- a/homeassistant/Makefile
+++ b/homeassistant/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=homeassistant
-PKG_VERSION:=2022.4.2
+PKG_VERSION:=2022.4.5
 PKG_RELEASE:=1
 
 PYPI_NAME:=homeassistant
-PKG_HASH:=d744af61d5e110cdfc9926a5cb914e3737fef2c89a3444b8c264f12f1303459c
+PKG_HASH:=76c2d52785fa212e5f91ca79356e2d628ade1332a8397d24183c969a750affdb
 
 PKG_MAINTAINER:=Lenar Mahmutov <lenz1986@gmail.com>
 PKG_LICENSE:=Apache-2.0
@@ -27,6 +27,7 @@ define Package/homeassistant
   CATEGORY:=Homeassistant
   TITLE:=Open source home automation
   URL:=https://github.com/home-assistant/core
+  USERID:=homeassistant:homeassistant
   DEPENDS:= \
 	+python3-dev \
 	+python3-pip

--- a/homeassistant/files/homeassistant
+++ b/homeassistant/files/homeassistant
@@ -3,11 +3,15 @@ START=99
 USE_PROCD=1
 start_service()
 {
+    chown -R homeassistant:homeassistant /etc/homeassistant
+    mkdir -p /var/log/ha
+    chown homeassistant:homeassistant /var/log/ha
     procd_open_instance
-    procd_set_param command hass --config /etc/homeassistant --log-file /var/log/home-assistant.log --log-rotate-days 3
+    procd_set_param user homeassistant
+    procd_set_param command hass --config /etc/homeassistant --log-file /var/log/ha/home-assistant.log --log-rotate-days 3
     procd_set_param stdout 1
     procd_set_param stderr 1
-    procd_set_param respawn ${respawn_threshold:-3600} ${respawn_timeout:-5} ${respawn_retry:-5}
+    procd_set_param respawn ${respawn_threshold:-70} ${respawn_timeout:-5} ${respawn_retry:-5}
     # use HUP to reload
     procd_set_param reload_signal HUP
     # terminate using signals

--- a/homeassistant/patches/002-add-setup_py.patch
+++ b/homeassistant/patches/002-add-setup_py.patch
@@ -5,7 +5,7 @@
 +
 +setup(
 +    name="Home Assistant",
-+    version="2022.4.2",
++    version="2022.4.5",
 +    description="Home Assistant",
 +    url="https://www.home-assistant.io/",
 +    author="The Home Assistant Authors",


### PR DESCRIPTION
also tune respawn threshold so it won't fail if you restart HA too often
HA run as unprivileged user

Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>